### PR TITLE
This keeps the original terminal background. (at least in gnome-terminal, ubuntu)

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -2,6 +2,9 @@ import curses
 
 class ChatUI:
     def __init__(self, stdscr, userlist_width=16):
+        curses.use_default_colors()
+        for i in range(0, curses.COLORS):
+            curses.init_pair(i, i, -1);
         self.stdscr = stdscr
         self.userlist = []
         self.inputbuffer = ""


### PR DESCRIPTION
Taken from: http://stackoverflow.com/questions/18551558/how-to-use-terminal-color-palette-with-curses#answer-18683506
